### PR TITLE
feat(mkhome): better change status handling

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,13 +28,13 @@
   register: check_mkhomedir
   ignore_errors: true
   check_mode: no
-  changed_when: false
-  failed_when: false
+  changed_when: "check_mkhomedir.rc != 0"
+  failed_when: "check_mkhomedir.rc not in [0, 1]"
 
 - name: configure pam to create homedirs when needed
   ansible.builtin.command:
     cmd: /usr/sbin/pam-auth-update --enable mkhomedir
-  when: ( check_mkhomedir.stdout_lines | length ) == 0
+  when: check_mkhomedir.changed
 
 - name: configure pam cifs mounts
   ansible.builtin.lineinfile:


### PR DESCRIPTION
@nis65 a small change to the change handling in mkhomedir:
- It now checks the exit code of the grep command instead of the line outputs
- it *actually* fails when the exit code is neither 0 or 1 (e.g. the file doesn't exist), which will return exit status 2
- The check command will be marked as *changed* when the exit code of the command is not 0. IMO the most important thing. Because when run with `-C` it now shows a change when it would do something. Before it just always showed green in check mode.

Mostly for "educational" purposes (or to discuss this), as I've used this pattern in *many* playbooks 'till now and figured that this approach (to me) looks the most clean.

I've also used `grep -q` but I just saw in the docs that this returns `0` even when there is an error 🙈 Always learn something new! 😄 